### PR TITLE
Reduce test duration

### DIFF
--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -30,8 +30,8 @@ from keras import backend
 from multiprocessing import Process, Queue
 
 
-MOBILENET_LIST = [(mobilenet.MobileNet, 1024),
-                  (mobilenet_v2.MobileNetV2, 1280)]
+MOBILENET_LIST = [(mobilenet.MobileNet, mobilenet, 1024),
+                  (mobilenet_v2.MobileNetV2, mobilenet_v2, 1280)]
 DENSENET_LIST = [(densenet.DenseNet121, 1024),
                  (densenet.DenseNet169, 1664),
                  (densenet.DenseNet201, 1920)]
@@ -190,8 +190,7 @@ def test_inceptionresnetv2():
 
 
 def test_mobilenet():
-    app, last_dim = random.choice(MOBILENET_LIST)
-    module = mobilenet
+    app, module, last_dim = random.choice(MOBILENET_LIST)
     _test_application_basic(app, module=module)
     _test_application_notop(app, last_dim)
     _test_application_variable_input_channels(app, last_dim)


### PR DESCRIPTION
In this PR: 

- Fix of a small error in `test_mobilenet`: selected module was always `mobilenet` even if selected app was `mobilenet_v2.MobileNetV2`
- Regroup `inception_v3` and `inception_resnet_v2` in a `random.choice(INCEPTION_LIST)` as each network tests take 300s and 120s to run