### PR TITLE
Include license and tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+include CONTRIBUTING.md
+graft tests


### PR DESCRIPTION
The license requires all copies of the program include a copy of the license.  And the tests are useful for downstreams, such as linux packagers, to make sure everything is running correctly.

This is from the MANIFEST.in file of [Keras-Preprocessing](https://github.com/keras-team/keras-preprocessing/blob/master/MANIFEST.in)