### PR TITLE
Fix tensor error in mobilenet_v2 preprocess_input

### DIFF
--- a/keras_applications/mobilenet_v2.py
+++ b/keras_applications/mobilenet_v2.py
@@ -110,7 +110,10 @@ def preprocess_input(x, **kwargs):
     """
     x /= 128.
     x -= 1.
-    return x.astype(np.float32)
+    if isinstance(x, np.ndarray):
+        return x.astype(np.float32)
+    else:
+        return x
 
 
 # This function is taken from the original tf repo.


### PR DESCRIPTION
Fix error while calling mobilenet_v2.preprocess_input(tensor):
```python
AttributeError: 'Tensor' object has no attribute 'astype'
```