### PR TITLE
Fix for issue #69

### DIFF
--- a/keras_applications/__init__.py
+++ b/keras_applications/__init__.py
@@ -56,13 +56,19 @@ def get_keras_submodule(name):
 
 
 def get_submodules_from_kwargs(kwargs):
-    backend = kwargs.get('backend', _KERAS_BACKEND)
-    layers = kwargs.get('layers', _KERAS_LAYERS)
-    models = kwargs.get('models', _KERAS_MODELS)
-    utils = kwargs.get('utils', _KERAS_UTILS)
-    for key in kwargs.keys():
-        if key not in ['backend', 'layers', 'models', 'utils']:
-            raise TypeError('Invalid keyword argument: %s', key)
+    submodules = ['backend', 'layers', 'models', 'utils']
+    if not kwargs:
+        backend, layers, models, utils = [__import__('keras.' + submodule,
+                                          fromlist=submodule)
+                                          for submodule in submodules]
+    else:
+        backend = kwargs.get('backend', _KERAS_BACKEND)
+        layers = kwargs.get('layers', _KERAS_LAYERS)
+        models = kwargs.get('models', _KERAS_MODELS)
+        utils = kwargs.get('utils', _KERAS_UTILS)
+        for key in kwargs.keys():
+            if key not in submodules:
+                raise TypeError('Invalid keyword argument: %s', key)
     return backend, layers, models, utils
 
 
@@ -92,7 +98,7 @@ def correct_pad(backend, inputs, kernel_size):
     return ((correct[0] - adjust[0], correct[0]),
             (correct[1] - adjust[1], correct[1]))
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 
 
 from . import vgg16

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,13 @@ and is distributed under the MIT license.
 '''
 
 setup(name='Keras_Applications',
-      version='1.0.6',
+      version='1.0.7',
       description='Reference implementations of popular deep learning models',
       long_description=long_description,
       author='Keras Team',
       url='https://github.com/keras-team/keras-applications',
       download_url='https://github.com/keras-team/'
-                   'keras-applications/tarball/1.0.6',
+                   'keras-applications/tarball/1.0.7',
       license='MIT',
       install_requires=['numpy>=1.9.1',
                         'h5py'],


### PR DESCRIPTION
This PR attempts to fix #69 which was caused when no kwargs was supplied to the get_submodules_from_kwargs function. Tested on tf-nightly 1.13 and theano 1.0.4 with python 3.6.8 and 2.7.3. 