### PR TITLE
Add a support of `include_top=False` for ResNeXt

### DIFF
--- a/keras_applications/resnet_common.py
+++ b/keras_applications/resnet_common.py
@@ -26,6 +26,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import numpy as np
 
 from . import get_submodules_from_kwargs
 from .imagenet_utils import _obtain_input_shape
@@ -227,12 +228,12 @@ def block3(x, filters, kernel_size=3, stride=1, groups=32,
     x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)), name=name + '_2_pad')(x)
     x = layers.DepthwiseConv2D(kernel_size, strides=stride, depth_multiplier=c,
                                use_bias=False, name=name + '_2_conv')(x)
-    x_shape = backend.int_shape(x)[1:-1]
-    x = layers.Reshape(x_shape + (groups, c, c))(x)
-    output_shape = x_shape + (groups, c) if backend.backend() == 'theano' else None
-    x = layers.Lambda(lambda x: sum([x[:, :, :, :, i] for i in range(c)]),
-                      output_shape=output_shape, name=name + '_2_reduce')(x)
-    x = layers.Reshape(x_shape + (filters,))(x)
+    kernel = np.zeros((1, 1, filters * c, filters), dtype=np.float32)
+    for i in range(filters):
+        start = (i // c) * c * c + i % c
+        end = start + c * c
+        kernel[:, :, start:end:c, i] = 1.
+    x = layers.Lambda(lambda x: backend.conv2d(x, backend.variable(kernel)))(x)
     x = layers.BatchNormalization(axis=bn_axis, epsilon=1.001e-5,
                                   name=name + '_2_bn')(x)
     x = layers.Activation('relu', name=name + '_2_relu')(x)

--- a/keras_applications/resnet_common.py
+++ b/keras_applications/resnet_common.py
@@ -228,17 +228,15 @@ def block3(x, filters, kernel_size=3, stride=1, groups=32,
     x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)), name=name + '_2_pad')(x)
     x = layers.DepthwiseConv2D(kernel_size, strides=stride, depth_multiplier=c,
                                use_bias=False, name=name + '_2_conv')(x)
-    if backend.backend() == 'theano':
-        x_shape = backend.int_shape(x)[1:-1] + (filters,)
-    else:
-        x_shape = None
     kernel = np.zeros((1, 1, filters * c, filters), dtype=np.float32)
     for i in range(filters):
         start = (i // c) * c * c + i % c
         end = start + c * c
         kernel[:, :, start:end:c, i] = 1.
-    x = layers.Lambda(lambda x: backend.conv2d(x, backend.variable(kernel)),
-                      output_shape=x_shape, name=name + '_2_reduce')(x)
+    x = layers.Conv2D(filters, 1, use_bias=False, trainable=False,
+                      kernel_initializer={'class_name': 'Constant',
+                                          'config': {'value': kernel}},
+                      name=name + '_2_gconv')(x)
     x = layers.BatchNormalization(axis=bn_axis, epsilon=1.001e-5,
                                   name=name + '_2_bn')(x)
     x = layers.Activation('relu', name=name + '_2_relu')(x)
@@ -414,7 +412,8 @@ def ResNet(stack_fn,
                                             BASE_WEIGHTS_PATH + file_name,
                                             cache_subdir='models',
                                             file_hash=file_hash)
-        model.load_weights(weights_path)
+        by_name = True if 'resnext' in model_name else False
+        model.load_weights(weights_path, by_name=by_name)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -205,7 +205,11 @@ def test_resnetv2():
 def test_resnext():
     app = random.choice(RESNEXT_LIST)
     module = keras_applications.resnext
+    last_dim = 2048
     _test_application_basic(app, module=module)
+    _test_application_notop(app, last_dim)
+    _test_application_variable_input_channels(app, last_dim)
+    _test_app_pooling(app, last_dim)
 
 
 def test_vgg():


### PR DESCRIPTION
Currently, it is not possible to call `ResNeXt50(include_top=False)` because the reshape operation inside the ResNeXt requires static input shapes. This PR replaces the reshape with the lambda with conv2d in order to enable the case.

Test codes are:
```python
import numpy as np

from keras import backend as K
from keras.preprocessing import image
from keras.applications.resnext import ResNeXt50
from keras.applications.resnext import preprocess_input, decode_predictions

img = image.load_img('cat.png', target_size=(256, 256))
x = image.img_to_array(img)[16:-16, 16:-16]
x = np.expand_dims(x, axis=0)
x = preprocess_input(x)

model = ResNeXt50(weights='imagenet', include_top=True)
print(decode_predictions(model.predict(x), top=3)[0])

# Before this PR, both two raise the following error:
# ValueError: Tried to convert 'shape' to a tensor and failed. Error: None values not supported.
model2 = ResNeXt50(weights='imagenet', include_top=False, input_shape=(None, None, 3))
model3 = ResNeXt50(weights='imagenet', include_top=False, input_shape=None)

outs1 = K.function([model.layers[0].input], [model.layers[-3].output])([x])[0]
outs2 = model2.predict(x)
outs3 = model3.predict(x)

np.testing.assert_allclose(outs1, outs2)
np.testing.assert_allclose(outs2, outs3)

# After this PR, arbitrary input shapes are OK.
print(model2.predict(np.random.random((1, 224, 224, 3))).shape)
print(model2.predict(np.random.random((1, 400, 400, 3))).shape)
print(model3.predict(np.random.random((1, 500, 500, 3))).shape)
```

Results are:
```
[('n02112018', 'Pomeranian', 0.13667941), ('n02123394', 'Persian_cat', 0.06406643), ('n02124075', 'Egyptian_cat', 0.05045045)]
(1, 7, 7, 2048)
(1, 13, 13, 2048)
(1, 16, 16, 2048)
```