### PR TITLE
Add `by_name=True` when loading imagenet weights

### DIFF
--- a/keras_applications/densenet.py
+++ b/keras_applications/densenet.py
@@ -290,7 +290,7 @@ def DenseNet(blocks,
                     DENSENET201_WEIGHT_PATH_NO_TOP,
                     cache_subdir='models',
                     file_hash='c13680b51ded0fb44dff2d8f86ac8bb1')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras_applications/inception_resnet_v2.py
+++ b/keras_applications/inception_resnet_v2.py
@@ -361,7 +361,7 @@ def InceptionResNetV2(include_top=True,
                 BASE_WEIGHT_URL + fname,
                 cache_subdir='models',
                 file_hash='d19885ff4a710c122648d3b5c3b684e4')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras_applications/inception_v3.py
+++ b/keras_applications/inception_v3.py
@@ -388,7 +388,7 @@ def InceptionV3(include_top=True,
                 WEIGHTS_PATH_NO_TOP,
                 cache_subdir='models',
                 file_hash='bcbd6486424b2319ff4ef7d526e38f63')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras_applications/mobilenet.py
+++ b/keras_applications/mobilenet.py
@@ -317,7 +317,7 @@ def MobileNet(input_shape=None,
             weights_path = keras_utils.get_file(model_name,
                                                 weight_path,
                                                 cache_subdir='models')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras_applications/mobilenet_v2.py
+++ b/keras_applications/mobilenet_v2.py
@@ -435,7 +435,7 @@ def MobileNetV2(input_shape=None,
             weigh_path = BASE_WEIGHT_PATH + model_name
             weights_path = keras_utils.get_file(
                 model_name, weigh_path, cache_subdir='models')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras_applications/nasnet.py
+++ b/keras_applications/nasnet.py
@@ -271,7 +271,7 @@ def NASNet(input_shape=None,
                     NASNET_MOBILE_WEIGHT_PATH_NO_TOP,
                     cache_subdir='models',
                     file_hash='1ed92395b5b598bdda52abe5c0dbfd63')
-            model.load_weights(weights_path)
+            model.load_weights(weights_path, by_name=True)
         elif default_size == 331:  # large version
             if include_top:
                 weights_path = keras_utils.get_file(
@@ -285,7 +285,7 @@ def NASNet(input_shape=None,
                     NASNET_LARGE_WEIGHT_PATH_NO_TOP,
                     cache_subdir='models',
                     file_hash='d81d89dc07e6e56530c4e77faddd61b5')
-            model.load_weights(weights_path)
+            model.load_weights(weights_path, by_name=True)
         else:
             raise ValueError(
                 'ImageNet weights can only be loaded with NASNetLarge'

--- a/keras_applications/resnet50.py
+++ b/keras_applications/resnet50.py
@@ -288,7 +288,7 @@ def ResNet50(include_top=True,
                 WEIGHTS_PATH_NO_TOP,
                 cache_subdir='models',
                 md5_hash='a268eb855778b3df3c7506639542a6af')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
         if backend.backend() == 'theano':
             keras_utils.convert_all_kernels_in_model(model)
     elif weights is not None:

--- a/keras_applications/resnet_common.py
+++ b/keras_applications/resnet_common.py
@@ -408,7 +408,7 @@ def ResNet(stack_fn,
                                             BASE_WEIGHTS_PATH + file_name,
                                             cache_subdir='models',
                                             file_hash=file_hash)
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
     elif weights is not None:
         model.load_weights(weights)
 

--- a/keras_applications/vgg16.py
+++ b/keras_applications/vgg16.py
@@ -207,7 +207,7 @@ def VGG16(include_top=True,
                 WEIGHTS_PATH_NO_TOP,
                 cache_subdir='models',
                 file_hash='6d6bbae143d832006294945121d1f1fc')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
         if backend.backend() == 'theano':
             keras_utils.convert_all_kernels_in_model(model)
     elif weights is not None:

--- a/keras_applications/vgg19.py
+++ b/keras_applications/vgg19.py
@@ -219,7 +219,7 @@ def VGG19(include_top=True,
                 WEIGHTS_PATH_NO_TOP,
                 cache_subdir='models',
                 file_hash='253f8cb515780f3b799900260a226db6')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
         if backend.backend() == 'theano':
             keras_utils.convert_all_kernels_in_model(model)
     elif weights is not None:

--- a/keras_applications/xception.py
+++ b/keras_applications/xception.py
@@ -311,7 +311,7 @@ def Xception(include_top=True,
                 TF_WEIGHTS_PATH_NO_TOP,
                 cache_subdir='models',
                 file_hash='b0042744bf5b25fce3cb969f33bebb97')
-        model.load_weights(weights_path)
+        model.load_weights(weights_path, by_name=True)
         if backend.backend() == 'theano':
             keras_utils.convert_all_kernels_in_model(model)
     elif weights is not None:


### PR DESCRIPTION
I am trying to run a model that performs a simple preprocessing to the input before passing it to the encoder. I created a dummy version for illustration purpose. 

```python
import keras

img = keras.layers.Input(shape=(224, 224, 3), name='img')
x = keras.layers.Dense(3)(x)

model = keras.applications.vgg16.VGG16(
    input_tensor=x,
    weights='imagenet',
    include_top=False)

model.summary()
```

This code raises an exception due to the extra layer.

```
ValueError: You are trying to load a weight file containing 13 layers into a model with 14 layers.
```

We can easily fix the issue using `by_name=True` when we load imagenet weights, hence here is a PR changing the current behavior. Is there anything dangerous that I am missing?