### PR TITLE
Custom image size in Mobilenets v1 and v2

### DIFF
--- a/keras_applications/mobilenet.py
+++ b/keras_applications/mobilenet.py
@@ -203,11 +203,11 @@ def MobileNet(input_shape=None,
                              '`0.25`, `0.50`, `0.75` or `1.0` only.')
 
         if rows != cols or rows not in [128, 160, 192, 224]:
-            if rows is None:
-                rows = 224
-                warnings.warn('MobileNet shape is undefined.'
-                              ' Weights for input shape '
-                              '(224, 224) will be loaded.')
+            rows = 224
+            warnings.warn('`rows` is different from `cols` or '
+                          'not in [128, 160, 192, 224]. Weights'
+                          ' for input shape (224, 224) will be '
+                          'loaded as the default.')
 
     if input_tensor is None:
         img_input = layers.Input(shape=input_shape)

--- a/keras_applications/mobilenet.py
+++ b/keras_applications/mobilenet.py
@@ -204,10 +204,10 @@ def MobileNet(input_shape=None,
 
         if rows != cols or rows not in [128, 160, 192, 224]:
             rows = 224
-            warnings.warn('`rows` is different from `cols` or '
-                          'not in [128, 160, 192, 224]. Weights'
-                          ' for input shape (224, 224) will be '
-                          'loaded as the default.')
+            warnings.warn('`input_shape` is undefined or non-square, '
+                          'or `rows` is not in [128, 160, 192, 224]. '
+                          'Weights for input shape (224, 224) will be'
+                          ' loaded as the default.')
 
     if input_tensor is None:
         img_input = layers.Input(shape=input_shape)

--- a/keras_applications/mobilenet_v2.py
+++ b/keras_applications/mobilenet_v2.py
@@ -291,10 +291,10 @@ def MobileNetV2(input_shape=None,
 
         if rows != cols or rows not in [96, 128, 160, 192, 224]:
             rows = 224
-            warnings.warn('`rows` is different from `cols` or '
-                          'not in [96, 128, 160, 192, 224]. '
-                          'Weights for input shape (224, 224) '
-                          'will be loaded as the default.')
+            warnings.warn('`input_shape` is undefined or non-square, '
+                          'or `rows` is not in [96, 128, 160, 192, 224].'
+                          ' Weights for input shape (224, 224) will be'
+                          ' loaded as the default.')
 
     if input_tensor is None:
         img_input = layers.Input(shape=input_shape)

--- a/keras_applications/mobilenet_v2.py
+++ b/keras_applications/mobilenet_v2.py
@@ -290,11 +290,11 @@ def MobileNetV2(input_shape=None,
                              '`1.0`, `1.3` or `1.4` only.')
 
         if rows != cols or rows not in [96, 128, 160, 192, 224]:
-            if rows is None:
-                rows = 224
-                warnings.warn('MobileNet shape is undefined.'
-                              ' Weights for input shape'
-                              '(224, 224) will be loaded.')
+            rows = 224
+            warnings.warn('`rows` is different from `cols` or '
+                          'not in [96, 128, 160, 192, 224]. '
+                          'Weights for input shape (224, 224) '
+                          'will be loaded as the default.')
 
     if input_tensor is None:
         img_input = layers.Input(shape=input_shape)


### PR DESCRIPTION
At the moment, the MobileNets models try to load the weights which for some input_shape do not exist (one example is illustrated in [this issue](https://github.com/keras-team/keras-applications/issues/92#issuecomment-480958268)). This PR is related to [this one](https://github.com/keras-team/keras-applications/pull/94). 

Suggested solution:
Weights for the default size of 224 are loaded if `rows` is different from `cols` or not in [128, 160, 192, 224] for MobileNet_v1.
Weights for the default size of 224 are loaded if `rows` is different from `cols` or not in [96, 128, 160, 192, 224] for MobileNet_v2.
