### PR TITLE
EfficientNet Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and is distributed under the MIT license.
 
 - The top-k errors were obtained using Keras Applications with the **TensorFlow backend** on the **2012 ILSVRC ImageNet validation set** and may slightly differ from the original ones.
 The input size used was 224x224 for all models except NASNetLarge (331x331), InceptionV3 (299x299), InceptionResNetV2 (299x299), Xception (299x299), EfficientNet-B1 (240x240),
-EfficientNet-B2 (260x260), and EfficientNet-B3 (300x300).
+EfficientNet-B2 (260x260), EfficientNet-B3 (300x300), EfficientNet-B4 (380x380), and EfficientNet-B5 (456x456).
   * Top-1: single center crop, top-1 error
   * Top-5: single center crop, top-5 error
   * 10-5: ten crops (1 center + 4 corners and those mirrored ones), top-5 error
@@ -64,6 +64,8 @@ EfficientNet-B2 (260x260), and EfficientNet-B3 (300x300).
 | [EfficientNet-B1](keras_applications/efficientnet.py)          | 21.296      | 5.796       | 5.326       | 7.9M   | 6.6M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
 | [EfficientNet-B2](keras_applications/efficientnet.py)          | 20.374      | 5.202       | 4.802       | 9.2M   | 7.8M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
 | [EfficientNet-B3](keras_applications/efficientnet.py)          | 19.168      | 4.698       | 4.284       | 12.3M  | 10.8M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B4](keras_applications/efficientnet.py)          | 17.446      | 3.908       | 3.554       | 19.5M  | 17.7M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B5](keras_applications/efficientnet.py)          | 16.886      | 3.506       | 3.224       | 30.6M  | 28.5M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
 
 
 ## Reference implementations from the community

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and is distributed under the MIT license.
 
 - The top-k errors were obtained using Keras Applications with the **TensorFlow backend** on the **2012 ILSVRC ImageNet validation set** and may slightly differ from the original ones.
 The input size used was 224x224 for all models except NASNetLarge (331x331), InceptionV3 (299x299), InceptionResNetV2 (299x299), Xception (299x299), EfficientNet-B1 (240x240),
-EfficientNet-B2 (260x260), EfficientNet-B3 (300x300), EfficientNet-B4 (380x380), and EfficientNet-B5 (456x456).
+EfficientNet-B2 (260x260), EfficientNet-B3 (300x300), EfficientNet-B4 (380x380), EfficientNet-B5 (456x456), EfficientNet-B6 (528x528), and EfficientNet-B7 (600x600).
   * Top-1: single center crop, top-1 error
   * Top-5: single center crop, top-5 error
   * 10-5: ten crops (1 center + 4 corners and those mirrored ones), top-5 error
@@ -60,12 +60,14 @@ EfficientNet-B2 (260x260), EfficientNet-B3 (300x300), EfficientNet-B4 (380x380),
 | [DenseNet201](keras_applications/densenet.py)                  | 22.680      | 6.380       | 5.466       | 20.2M  | 18.3M  | [[paper]](https://arxiv.org/abs/1608.06993) [[torch]](https://github.com/liuzhuang13/DenseNet/blob/master/models/densenet.lua) |
 | [NASNetLarge](keras_applications/nasnet.py)                    | 17.502      | 3.996       | 3.412       | 93.5M  | 84.9M  | [[paper]](https://arxiv.org/abs/1707.07012) [[tf-models]](https://github.com/tensorflow/models/blob/master/research/slim/nets/nasnet/nasnet.py) |
 | [NASNetMobile](keras_applications/nasnet.py)                   | 25.634      | 8.146       | 6.758       | 7.7M   | 4.3M   | [[paper]](https://arxiv.org/abs/1707.07012) [[tf-models]](https://github.com/tensorflow/models/blob/master/research/slim/nets/nasnet/nasnet.py) |
-| [EfficientNet-B0](keras_applications/efficientnet.py)          | 23.354      | 6.806       | 6.206       | 5.3M   | 4.0M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
-| [EfficientNet-B1](keras_applications/efficientnet.py)          | 21.296      | 5.796       | 5.326       | 7.9M   | 6.6M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
-| [EfficientNet-B2](keras_applications/efficientnet.py)          | 20.374      | 5.202       | 4.802       | 9.2M   | 7.8M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
-| [EfficientNet-B3](keras_applications/efficientnet.py)          | 19.168      | 4.698       | 4.284       | 12.3M  | 10.8M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
-| [EfficientNet-B4](keras_applications/efficientnet.py)          | 17.446      | 3.908       | 3.554       | 19.5M  | 17.7M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
-| [EfficientNet-B5](keras_applications/efficientnet.py)          | 16.886      | 3.506       | 3.224       | 30.6M  | 28.5M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B0](keras_applications/efficientnet.py)          | 22.810      | 6.508       | 5.858       | 5.3M   | 4.0M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B1](keras_applications/efficientnet.py)          | 20.866      | 5.552       | 5.050       | 7.9M   | 6.6M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B2](keras_applications/efficientnet.py)          | 19.820      | 5.054       | 4.538       | 9.2M   | 7.8M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B3](keras_applications/efficientnet.py)          | 18.422      | 4.324       | 3.902       | 12.3M  | 10.8M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B4](keras_applications/efficientnet.py)          | 17.040      | 3.740       | 3.344       | 19.5M  | 17.7M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B5](keras_applications/efficientnet.py)          | 16.298      | 3.290       | 3.114       | 30.6M  | 28.5M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B6](keras_applications/efficientnet.py)          | 15.918      | 3.102       | 2.916       | 43.3M  | 41.0M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B7](keras_applications/efficientnet.py)          | 15.570      | 3.160       | 2.906       | 66.7M  | 64.1M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
 
 
 ## Reference implementations from the community

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ and is distributed under the MIT license.
 ## Performance
 
 - The top-k errors were obtained using Keras Applications with the **TensorFlow backend** on the **2012 ILSVRC ImageNet validation set** and may slightly differ from the original ones.
-The input size used was 224x224 for all models except NASNetLarge (331x331), InceptionV3 (299x299), InceptionResNetV2 (299x299), and Xception (299x299).
+The input size used was 224x224 for all models except NASNetLarge (331x331), InceptionV3 (299x299), InceptionResNetV2 (299x299), Xception (299x299), EfficientNet-B1 (240x240),
+EfficientNet-B2 (260x260), and EfficientNet-B3 (300x300).
   * Top-1: single center crop, top-1 error
   * Top-5: single center crop, top-5 error
   * 10-5: ten crops (1 center + 4 corners and those mirrored ones), top-5 error
@@ -59,6 +60,10 @@ The input size used was 224x224 for all models except NASNetLarge (331x331), Inc
 | [DenseNet201](keras_applications/densenet.py)                  | 22.680      | 6.380       | 5.466       | 20.2M  | 18.3M  | [[paper]](https://arxiv.org/abs/1608.06993) [[torch]](https://github.com/liuzhuang13/DenseNet/blob/master/models/densenet.lua) |
 | [NASNetLarge](keras_applications/nasnet.py)                    | 17.502      | 3.996       | 3.412       | 93.5M  | 84.9M  | [[paper]](https://arxiv.org/abs/1707.07012) [[tf-models]](https://github.com/tensorflow/models/blob/master/research/slim/nets/nasnet/nasnet.py) |
 | [NASNetMobile](keras_applications/nasnet.py)                   | 25.634      | 8.146       | 6.758       | 7.7M   | 4.3M   | [[paper]](https://arxiv.org/abs/1707.07012) [[tf-models]](https://github.com/tensorflow/models/blob/master/research/slim/nets/nasnet/nasnet.py) |
+| [EfficientNet-B0](keras_applications/efficientnet.py)          | 23.354      | 6.806       | 6.206       | 5.3M   | 4.0M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B1](keras_applications/efficientnet.py)          | 21.296      | 5.796       | 5.326       | 7.9M   | 6.6M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B2](keras_applications/efficientnet.py)          | 20.374      | 5.202       | 4.802       | 9.2M   | 7.8M   | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
+| [EfficientNet-B3](keras_applications/efficientnet.py)          | 19.168      | 4.698       | 4.284       | 12.3M  | 10.8M  | [[paper]](https://arxiv.org/abs/1905.11946) [[tf-tpu]](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet) |
 
 
 ## Reference implementations from the community

--- a/keras_applications/__init__.py
+++ b/keras_applications/__init__.py
@@ -63,3 +63,4 @@ from . import nasnet
 from . import resnet
 from . import resnet_v2
 from . import resnext
+from . import efficientnet

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -126,7 +126,7 @@ def round_repeats(repeats, depth_coefficient):
 
 
 
-def MBConvBlock(inputs, block_args, relu_fn=swish, prefix=''):
+def mb_conv_block(inputs, block_args, relu_fn=swish, prefix=''):
     """Mobile Inverted Residual Bottleneck."""
 
     has_se = (block_args.se_ratio is not None) and (0 < block_args.se_ratio <= 1)
@@ -306,14 +306,14 @@ def EfficientNet(width_coefficient,
             num_repeat=round_repeats(block_args.num_repeat, depth_coefficient))
 
         # The first block needs to take care of stride and filter size increase.
-        x = MBConvBlock(x, block_args, relu_fn=relu_fn, prefix='block{}a_'.format(idx+1))
+        x = mb_conv_block(x, block_args, relu_fn=relu_fn, prefix='block{}a_'.format(idx+1))
         if block_args.num_repeat > 1:
             # pylint: disable=protected-access
             block_args = block_args._replace(
                 input_filters=block_args.output_filters, strides=[1, 1])
             # pylint: enable=protected-access
             for bidx in xrange(block_args.num_repeat - 1):
-                x = MBConvBlock(x, block_args, relu_fn=relu_fn,
+                x = mb_conv_block(x, block_args, relu_fn=relu_fn,
                                 prefix='block{}{}_'.format(idx+1, string.ascii_lowercase[bidx+1]))
 
     # Build top

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -51,7 +51,15 @@ WEIGHTS_HASHES = {
     'efficientnet-b3': ('99725ac825f7ddf5e47c05d333d9fb62'
                         '3faf1640c0b0c7372f855804e1861508',
                         'e70d7ea35fa684f9046e6cc62783940b'
-                        'd83d16edc238807fb75c73105d7ffbaa')
+                        'd83d16edc238807fb75c73105d7ffbaa'),
+    'efficientnet-b4': ('242890effb990b11fdcc91fceb59cd74'
+                        '9388c6b712c96dfb597561d6dae3060a',
+                        'eaa6455c773db0f2d4d097f7da771bb7'
+                        '25dd8c993ac6f4553b78e12565999fc1'),
+    'efficientnet-b5': ('c4cb66916633b7311688dbcf6ed5c35e'
+                        '45ce06594181066015c001103998dc67',
+                        '14161a20506013aa229abce8fd994b45'
+                        'da76b3a29e1c011635376e191c2c2d54')
 }
 
 MEAN_RGB = [0.485 * 255, 0.456 * 255, 0.406 * 255]
@@ -298,7 +306,7 @@ def EfficientNet(width_coefficient,
 
     if weights == 'imagenet' and (model_name not in WEIGHTS_HASHES):
         raise ValueError('Pre-trained weights are only available for '
-                         'EfficientNet-B0 to -B3, but you requested weights for ' +
+                         'EfficientNet-B0 to -B5, but you requested weights for ' +
                          model_name + '.')
 
     # Determine proper input shape

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -1,0 +1,543 @@
+"""EfficientNet models for Keras.
+
+# Reference papers
+
+- [EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks]
+  (https://arxiv.org/abs/1905.11946) (ICML 2019)
+
+# Reference implementations
+
+- [Tensorflow]
+  (https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet)
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import collections
+import math
+import string
+import json
+import numpy as np
+from six.moves import xrange
+
+from keras_applications import get_submodules_from_kwargs
+from keras_applications.imagenet_utils import _obtain_input_shape
+
+
+backend = None
+layers = None
+models = None
+keras_utils = None
+
+
+BASE_WEIGHTS_PATH = (
+    'https://github.com/keras-team/keras-applications/'
+    'releases/download/efficientnet/')
+WEIGHTS_HASHES = {
+    'efficientnet-b0': ('e423137a2235dfc8166aac54ba9f306fb1f2f77843d88f9437079952e9b3622f',
+                        '')
+}
+
+CLASS_INDEX = None
+CLASS_INDEX_PATH = ('https://storage.googleapis.com/cloud-tpu-checkpoints/'
+                    'efficientnet/eval_data/labels_map.txt')
+
+
+BlockArgs = collections.namedtuple('BlockArgs', [
+    'kernel_size', 'num_repeat', 'input_filters', 'output_filters',
+    'expand_ratio', 'id_skip', 'strides', 'se_ratio'
+])
+# defaults will be a public argument for namedtuple in Python 3.7
+# https://docs.python.org/3/library/collections.html#collections.namedtuple
+BlockArgs.__new__.__defaults__ = (None,) * len(BlockArgs._fields)
+
+
+DEFAULT_BLOCKS_ARGS = [
+    BlockArgs(kernel_size=3, num_repeat=1, input_filters=32, output_filters=16,
+              expand_ratio=1, id_skip=True, strides=[1, 1], se_ratio=0.25),
+    BlockArgs(kernel_size=3, num_repeat=2, input_filters=16, output_filters=24,
+              expand_ratio=6, id_skip=True, strides=[2, 2], se_ratio=0.25),
+    BlockArgs(kernel_size=5, num_repeat=2, input_filters=24, output_filters=40,
+              expand_ratio=6, id_skip=True, strides=[2, 2], se_ratio=0.25),
+    BlockArgs(kernel_size=3, num_repeat=3, input_filters=40, output_filters=80,
+              expand_ratio=6, id_skip=True, strides=[2, 2], se_ratio=0.25),
+    BlockArgs(kernel_size=5, num_repeat=3, input_filters=80, output_filters=112,
+              expand_ratio=6, id_skip=True, strides=[1, 1], se_ratio=0.25),
+    BlockArgs(kernel_size=5, num_repeat=4, input_filters=112, output_filters=192,
+              expand_ratio=6, id_skip=True, strides=[2, 2], se_ratio=0.25),
+    BlockArgs(kernel_size=3, num_repeat=1, input_filters=192, output_filters=320,
+              expand_ratio=6, id_skip=True, strides=[1, 1], se_ratio=0.25)
+]
+
+
+def swish(x):
+    """Swish activation function: x * sigmoid(x).
+
+    Reference: [Searching for Activation Functions](https://arxiv.org/abs/1710.05941)
+    """
+
+    if backend.backend() == 'tensorflow':
+        try:
+            # The native TF implementation has a more memory-efficient gradient implementation
+            return backend.tf.nn.swish(x)
+        except:
+            pass
+
+    return x * backend.sigmoid(x)
+
+
+def conv_kernel_initializer(shape, dtype=None):
+    """Initialization for convolutional kernels.
+
+    The main difference with VarianceScaling is that
+    VarianceScaling uses a truncated normal with an uncorrected
+    standard deviation, whereas here we use a normal distribution.
+    """
+
+    kernel_height, kernel_width, _, out_filters = shape
+    fan_out = int(kernel_height * kernel_width * out_filters)
+    return backend.random_normal(shape, mean=0.0, stddev=np.sqrt(2.0 / fan_out), dtype=dtype)
+
+
+def round_filters(filters, width_coefficient, depth_divisor):
+    """Round number of filters based on width multiplier."""
+
+    filters *= width_coefficient
+    new_filters = max(depth_divisor,
+                      int(filters + depth_divisor / 2) // depth_divisor * depth_divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_filters < 0.9 * filters:
+        new_filters += depth_divisor
+    return int(new_filters)
+
+
+def round_repeats(repeats, depth_coefficient):
+    """Round number of repeats based on depth multiplier."""
+
+    return int(math.ceil(depth_coefficient * repeats))
+
+
+
+def MBConvBlock(inputs, block_args, relu_fn=swish, prefix=''):
+    """Mobile Inverted Residual Bottleneck."""
+
+    has_se = (block_args.se_ratio is not None) and (0 < block_args.se_ratio <= 1)
+    bn_axis = 3 if backend.image_data_format() == 'channels_last' else 1
+
+    # Expansion phase
+    filters = block_args.input_filters * block_args.expand_ratio
+    if block_args.expand_ratio != 1:
+        x = layers.Conv2D(filters, 1,
+                          padding='same',
+                          use_bias=False,
+                          kernel_initializer=conv_kernel_initializer,
+                          name=prefix+'expand_conv')(inputs)
+        x = layers.BatchNormalization(axis=bn_axis, name=prefix+'expand_bn')(x)
+        x = layers.Activation(relu_fn, name=prefix+'expand_activation')(x)
+    else:
+        x = inputs
+
+    # Depthwise Convolution
+    x = layers.DepthwiseConv2D(block_args.kernel_size,
+                               strides=block_args.strides,
+                               padding='same',
+                               use_bias=False,
+                               depthwise_initializer=conv_kernel_initializer,
+                               name=prefix+'dwconv')(x)
+    x = layers.BatchNormalization(axis=bn_axis, name=prefix+'bn')(x)
+    x = layers.Activation(relu_fn, name=prefix+'activation')(x)
+
+    # Squeeze and Excitation phase
+    if has_se:
+        num_reduced_filters = max(1, int(block_args.input_filters * block_args.se_ratio))
+        se_tensor = layers.GlobalAveragePooling2D(name=prefix+'se_squeeze')(x)
+        se_tensor = layers.Reshape((1, 1, filters), name=prefix+'se_reshape')(se_tensor)
+        se_tensor = layers.Conv2D(num_reduced_filters, 1,
+                                  activation=relu_fn,
+                                  padding='same',
+                                  use_bias=True,
+                                  kernel_initializer=conv_kernel_initializer,
+                                  name=prefix+'se_reduce')(se_tensor)
+        se_tensor = layers.Conv2D(filters, 1,
+                                  activation='sigmoid',
+                                  padding='same',
+                                  use_bias=True,
+                                  kernel_initializer=conv_kernel_initializer,
+                                  name=prefix+'se_expand')(se_tensor)
+        x = layers.multiply([x, se_tensor], name=prefix+'se_excite')
+
+    # Output phase
+    x = layers.Conv2D(block_args.output_filters, 1,
+                      padding='same',
+                      use_bias=False,
+                      kernel_initializer=conv_kernel_initializer,
+                      name=prefix+'project_conv')(x)
+    x = layers.BatchNormalization(axis=bn_axis, name=prefix+'project_bn')(x)
+    if block_args.id_skip and all(
+            s == 1 for s in block_args.strides
+    ) and block_args.input_filters == block_args.output_filters:
+        x = layers.add([x, inputs], name=prefix+'add')
+
+    return x
+
+
+
+def EfficientNet(width_coefficient,
+                 depth_coefficient,
+                 default_resolution,
+                 dropout_rate=0.2,
+                 depth_divisor=8,
+                 relu_fn=swish,
+                 blocks_args=DEFAULT_BLOCKS_ARGS,
+                 model_name='efficientnet',
+                 include_top=True,
+                 weights='imagenet',
+                 input_tensor=None,
+                 input_shape=None,
+                 pooling=None,
+                 classes=1000,
+                 **kwargs):
+    """Instantiates the EfficientNet architecture using given scaling coefficients.
+
+    Optionally loads weights pre-trained on ImageNet.
+    Note that the data format convention used by the model is
+    the one specified in your Keras config at `~/.keras/keras.json`.
+
+    # Arguments
+        width_coefficient: float, scaling coefficient for network width.
+        depth_coefficient: float, scaling coefficient for network depth.
+        default_resolution: int, default input image size.
+        dropout_rate: float, dropout rate.
+        depth_divisor: int.
+        blocks_args: A list of BlockArgs to construct block modules.
+        model_name: string, model name.
+        include_top: whether to include the fully-connected
+            layer at the top of the network.
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or the path to the weights file to be loaded.
+        input_tensor: optional Keras tensor
+            (i.e. output of `layers.Input()`)
+            to use as image input for the model.
+        input_shape: optional shape tuple, only to be specified
+            if `include_top` is False.
+            It should have exactly 3 inputs channels.
+        pooling: optional pooling mode for feature extraction
+            when `include_top` is `False`.
+            - `None` means that the output of the model will be
+                the 4D tensor output of the
+                last convolutional layer.
+            - `avg` means that global average pooling
+                will be applied to the output of the
+                last convolutional layer, and thus
+                the output of the model will be a 2D tensor.
+            - `max` means that global max pooling will
+                be applied.
+        classes: optional number of classes to classify images
+            into, only to be specified if `include_top` is True, and
+            if no `weights` argument is specified.
+
+    # Returns
+        A Keras model instance.
+
+    # Raises
+        ValueError: in case of invalid argument for `weights`,
+            or invalid input shape.
+    """
+    global backend, layers, models, keras_utils
+    backend, layers, models, keras_utils = get_submodules_from_kwargs(kwargs)
+
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
+        raise ValueError('The `weights` argument should be either '
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or the path to the weights file to be loaded.')
+
+    if weights == 'imagenet' and include_top and classes != 1000:
+        raise ValueError('If using `weights` as `"imagenet"` with `include_top`'
+                         ' as true, `classes` should be 1000')
+
+    # Determine proper input shape
+    input_shape = _obtain_input_shape(input_shape,
+                                      default_size=default_resolution,
+                                      min_size=32,
+                                      data_format=backend.image_data_format(),
+                                      require_flatten=include_top,
+                                      weights=weights)
+
+    if input_tensor is None:
+        img_input = layers.Input(shape=input_shape)
+    else:
+        if not backend.is_keras_tensor(input_tensor):
+            img_input = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            img_input = input_tensor
+
+    bn_axis = 3 if backend.image_data_format() == 'channels_last' else 1
+
+    # Build stem
+    x = img_input
+    x = layers.Conv2D(round_filters(32, width_coefficient, depth_divisor), 3,
+                      strides=(2, 2),
+                      padding='same',
+                      use_bias=False,
+                      kernel_initializer=conv_kernel_initializer,
+                      name='stem_conv')(x)
+    x = layers.BatchNormalization(axis=bn_axis, name='stem_bn')(x)
+    x = layers.Activation(relu_fn, name='stem_activation')(x)
+
+    # Build blocks
+    for idx, block_args in enumerate(blocks_args):
+        assert block_args.num_repeat > 0
+        # Update block input and output filters based on depth multiplier.
+        block_args = block_args._replace(
+            input_filters=round_filters(block_args.input_filters,
+                                        width_coefficient, depth_divisor),
+            output_filters=round_filters(block_args.output_filters,
+                                         width_coefficient, depth_divisor),
+            num_repeat=round_repeats(block_args.num_repeat, depth_coefficient))
+
+        # The first block needs to take care of stride and filter size increase.
+        x = MBConvBlock(x, block_args, relu_fn=relu_fn, prefix='block{}a_'.format(idx+1))
+        if block_args.num_repeat > 1:
+            # pylint: disable=protected-access
+            block_args = block_args._replace(
+                input_filters=block_args.output_filters, strides=[1, 1])
+            # pylint: enable=protected-access
+            for bidx in xrange(block_args.num_repeat - 1):
+                x = MBConvBlock(x, block_args, relu_fn=relu_fn,
+                                prefix='block{}{}_'.format(idx+1, string.ascii_lowercase[bidx+1]))
+
+    # Build top
+    x = layers.Conv2D(round_filters(1280, width_coefficient, depth_divisor), 1,
+                      padding='same',
+                      use_bias=False,
+                      kernel_initializer=conv_kernel_initializer,
+                      name='top_conv')(x)
+    x = layers.BatchNormalization(axis=bn_axis, name='top_bn')(x)
+    x = layers.Activation(relu_fn, name='top_activation')(x)
+    if include_top:
+        x = layers.GlobalAveragePooling2D(name='avg_pool')(x)
+        if dropout_rate and dropout_rate > 0:
+            x = layers.Dropout(dropout_rate, name='top_dropout')(x)
+        # kernel_initializer in reference implementation:
+        # keras.initializers.VarianceScaling(1.0/3.0, mode='fan_out', distribution='uniform')
+        x = layers.Dense(classes, activation='softmax', name='probs')(x)
+    else:
+        if pooling == 'avg':
+            x = layers.GlobalAveragePooling2D(name='avg_pool')(x)
+        elif pooling == 'max':
+            x = layers.GlobalMaxPooling2D(name='max_pool')(x)
+
+    # Ensure that the model takes into account
+    # any potential predecessors of `input_tensor`.
+    if input_tensor is not None:
+        inputs = keras_utils.get_source_inputs(input_tensor)
+    else:
+        inputs = img_input
+
+    # Create model.
+    model = models.Model(inputs, x, name=model_name)
+
+    # Load weights.
+    if (weights == 'imagenet') and (model_name in WEIGHTS_HASHES):
+        if include_top:
+            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels.h5'
+            file_hash = WEIGHTS_HASHES[model_name][0]
+        else:
+            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_notop.h5'
+            file_hash = WEIGHTS_HASHES[model_name][1]
+        weights_path = keras_utils.get_file(file_name,
+                                            BASE_WEIGHTS_PATH + file_name,
+                                            cache_subdir='models',
+                                            file_hash=file_hash)
+        model.load_weights(weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
+
+    return model
+
+
+def EfficientNetB0(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(1.0, 1.0, 224, 0.2,
+                        model_name='efficientnet-b0',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+def EfficientNetB1(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(1.0, 1.1, 240, 0.2,
+                        model_name='efficientnet-b1',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+def EfficientNetB2(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(1.1, 1.2, 260, 0.3,
+                        model_name='efficientnet-b2',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+def EfficientNetB3(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(1.2, 1.4, 300, 0.3,
+                        model_name='efficientnet-b3',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+def EfficientNetB4(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(1.4, 1.8, 380, 0.4,
+                        model_name='efficientnet-b4',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+def EfficientNetB5(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(1.6, 2.2, 456, 0.4,
+                        model_name='efficientnet-b5',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+def EfficientNetB6(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(1.8, 2.6, 528, 0.5,
+                        model_name='efficientnet-b6',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+def EfficientNetB7(include_top=True,
+                   weights='imagenet',
+                   input_tensor=None,
+                   input_shape=None,
+                   pooling=None,
+                   classes=1000,
+                   **kwargs):
+    return EfficientNet(2.0, 3.1, 600, 0.5,
+                        model_name='efficientnet-b7',
+                        include_top=include_top, weights=weights,
+                        input_tensor=input_tensor, input_shape=input_shape,
+                        pooling=pooling, classes=classes,
+                        **kwargs)
+
+
+setattr(EfficientNetB0, '__doc__', EfficientNet.__doc__)
+setattr(EfficientNetB1, '__doc__', EfficientNet.__doc__)
+setattr(EfficientNetB2, '__doc__', EfficientNet.__doc__)
+setattr(EfficientNetB3, '__doc__', EfficientNet.__doc__)
+setattr(EfficientNetB4, '__doc__', EfficientNet.__doc__)
+setattr(EfficientNetB5, '__doc__', EfficientNet.__doc__)
+setattr(EfficientNetB6, '__doc__', EfficientNet.__doc__)
+setattr(EfficientNetB7, '__doc__', EfficientNet.__doc__)
+
+
+
+def preprocess_input(x, **kwargs):
+    """Preprocesses a numpy array encoding a batch of images.
+    # Arguments
+        x: a 4D numpy array consists of RGB values within [0, 255].
+    # Returns
+        Preprocessed array.
+    """
+
+    if isinstance(x, np.ndarray) and not issubclass(x.dtype.type, np.floating):
+        backend, _, _, _ = get_submodules_from_kwargs(kwargs)
+        x = x.astype(backend.floatx(), copy=False)
+    return x / 255.
+
+
+def decode_predictions(preds, top=5, **kwargs):
+    """Decodes the prediction of an ImageNet model.
+    # Arguments
+        preds: Numpy tensor encoding a batch of predictions.
+        top: Integer, how many top-guesses to return.
+    # Returns
+        A list of lists of top class prediction tuples
+        `(class_name, class_description, score)`.
+        One list of tuples per sample in batch input.
+    # Raises
+        ValueError: In case of invalid shape of the `pred` array
+            (must be 2D).
+    """
+    global CLASS_INDEX
+
+    _, _, _, keras_utils = get_submodules_from_kwargs(kwargs)
+
+    if len(preds.shape) != 2 or preds.shape[1] != 1000:
+        raise ValueError('`decode_predictions` expects '
+                         'a batch of predictions '
+                         '(i.e. a 2D array of shape (samples, 1000)). '
+                         'Found array with shape: ' + str(preds.shape))
+    if CLASS_INDEX is None:
+        fpath = keras_utils.get_file(
+            'efficientnet_class_index.json',
+            CLASS_INDEX_PATH,
+            cache_subdir='models',
+            file_hash='3e232637a09beeb733f409908cfc0ba256e83f06815684678abafd4c0990c757')
+        with open(fpath) as f:
+            CLASS_INDEX = json.load(f)
+    results = []
+    for pred in preds:
+        top_indices = pred.argsort()[-top:][::-1]
+        result = [(CLASS_INDEX[str(i)], pred[i]) for i in top_indices]
+        results.append(result)
+    return results

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -54,19 +54,19 @@ WEIGHTS_HASHES = {
 
 DEFAULT_BLOCKS_ARGS = [
     {'kernel_size': 3, 'repeats': 1, 'filters_in': 32, 'filters_out': 16,
-     'expand_ratio': 1, 'id_skip': True, 'strides': [1, 1], 'se_ratio': 0.25},
+     'expand_ratio': 1, 'id_skip': True, 'strides': 1, 'se_ratio': 0.25},
     {'kernel_size': 3, 'repeats': 2, 'filters_in': 16, 'filters_out': 24,
-     'expand_ratio': 6, 'id_skip': True, 'strides': [2, 2], 'se_ratio': 0.25},
+     'expand_ratio': 6, 'id_skip': True, 'strides': 2, 'se_ratio': 0.25},
     {'kernel_size': 5, 'repeats': 2, 'filters_in': 24, 'filters_out': 40,
-     'expand_ratio': 6, 'id_skip': True, 'strides': [2, 2], 'se_ratio': 0.25},
+     'expand_ratio': 6, 'id_skip': True, 'strides': 2, 'se_ratio': 0.25},
     {'kernel_size': 3, 'repeats': 3, 'filters_in': 40, 'filters_out': 80,
-     'expand_ratio': 6, 'id_skip': True, 'strides': [2, 2], 'se_ratio': 0.25},
+     'expand_ratio': 6, 'id_skip': True, 'strides': 2, 'se_ratio': 0.25},
     {'kernel_size': 5, 'repeats': 3, 'filters_in': 80, 'filters_out': 112,
-     'expand_ratio': 6, 'id_skip': True, 'strides': [1, 1], 'se_ratio': 0.25},
+     'expand_ratio': 6, 'id_skip': True, 'strides': 1, 'se_ratio': 0.25},
     {'kernel_size': 5, 'repeats': 4, 'filters_in': 112, 'filters_out': 192,
-     'expand_ratio': 6, 'id_skip': True, 'strides': [2, 2], 'se_ratio': 0.25},
+     'expand_ratio': 6, 'id_skip': True, 'strides': 2, 'se_ratio': 0.25},
     {'kernel_size': 3, 'repeats': 1, 'filters_in': 192, 'filters_out': 320,
-     'expand_ratio': 6, 'id_skip': True, 'strides': [1, 1], 'se_ratio': 0.25}
+     'expand_ratio': 6, 'id_skip': True, 'strides': 1, 'se_ratio': 0.25}
 ]
 
 CONV_KERNEL_INITIALIZER = {
@@ -115,41 +115,32 @@ def swish(x):
     return x * backend.sigmoid(x)
 
 
-def round_filters(filters, width_coefficient, depth_divisor):
-    """Round number of filters based on depth multiplier."""
-    filters *= width_coefficient
-    new_filters = int(filters + depth_divisor / 2) // depth_divisor * depth_divisor
-    new_filters = max(depth_divisor, new_filters)
-    # Make sure that round down does not go down by more than 10%.
-    if new_filters < 0.9 * filters:
-        new_filters += depth_divisor
-    return int(new_filters)
-
-
-def round_repeats(repeats, depth_coefficient):
-    """Round number of repeats based on depth multiplier."""
-    return int(math.ceil(depth_coefficient * repeats))
-
-
-def block(inputs, drop_rate=None, activation_fn=swish, name='', **kwargs):
+def block(inputs, activation_fn=swish, drop_rate=0., name='',
+          filters_in=32, filters_out=16, kernel_size=3, strides=1,
+          expand_ratio=1, se_ratio=0., id_skip=True):
     """A mobile inverted residual block.
 
     # Arguments
         inputs: input tensor.
-        args: dict, block arguments.
-        drop_rate: float between 0 and 1, fraction of the input units to drop.
         activation_fn: activation function.
+        drop_rate: float between 0 and 1, fraction of the input units to drop.
         name: string, block label.
+        filters_in: integer, the number of input filters.
+        filters_out: integer, the number of output filters.
+        kernel_size: integer, the dimension of the convolution window.
+        strides: integer, the stride of the convolution.
+        expand_ratio: integer, scaling coefficient for the input filters.
+        se_ratio: float between 0 and 1, fraction to squeeze the input filters.
+        id_skip: boolean.
 
     # Returns
         output tensor for the block.
     """
-    has_se = (kwargs['se_ratio'] is not None) and (0 < kwargs['se_ratio'] <= 1)
     bn_axis = 3 if backend.image_data_format() == 'channels_last' else 1
 
     # Expansion phase
-    filters = kwargs['filters_in'] * kwargs['expand_ratio']
-    if kwargs['expand_ratio'] != 1:
+    filters = filters_in * expand_ratio
+    if expand_ratio != 1:
         x = layers.Conv2D(filters, 1,
                           padding='same',
                           use_bias=False,
@@ -161,8 +152,8 @@ def block(inputs, drop_rate=None, activation_fn=swish, name='', **kwargs):
         x = inputs
 
     # Depthwise Convolution
-    x = layers.DepthwiseConv2D(kwargs['kernel_size'],
-                               strides=kwargs['strides'],
+    x = layers.DepthwiseConv2D(kernel_size,
+                               strides=strides,
                                padding='same',
                                use_bias=False,
                                depthwise_initializer=CONV_KERNEL_INITIALIZER,
@@ -171,40 +162,38 @@ def block(inputs, drop_rate=None, activation_fn=swish, name='', **kwargs):
     x = layers.Activation(activation_fn, name=name + 'activation')(x)
 
     # Squeeze and Excitation phase
-    if has_se:
-        reduced_filters = max(1, int(kwargs['filters_in'] * kwargs['se_ratio']))
-        se_tensor = layers.GlobalAveragePooling2D(name=name + 'se_squeeze')(x)
-        se_tensor = layers.Reshape((1, 1, filters),
-                                   name=name + 'se_reshape')(se_tensor)
-        se_tensor = layers.Conv2D(reduced_filters, 1,
-                                  activation=activation_fn,
-                                  padding='same',
-                                  kernel_initializer=CONV_KERNEL_INITIALIZER,
-                                  name=name + 'se_reduce')(se_tensor)
-        se_tensor = layers.Conv2D(filters, 1,
-                                  activation='sigmoid',
-                                  padding='same',
-                                  kernel_initializer=CONV_KERNEL_INITIALIZER,
-                                  name=name + 'se_expand')(se_tensor)
+    if 0 < se_ratio <= 1:
+        filters_se = max(1, int(filters_in * se_ratio))
+        se = layers.GlobalAveragePooling2D(name=name + 'se_squeeze')(x)
+        se = layers.Reshape((1, 1, filters), name=name + 'se_reshape')(se)
+        se = layers.Conv2D(filters_se, 1,
+                           padding='same',
+                           activation=activation_fn,
+                           kernel_initializer=CONV_KERNEL_INITIALIZER,
+                           name=name + 'se_reduce')(se)
+        se = layers.Conv2D(filters, 1,
+                           padding='same',
+                           activation='sigmoid',
+                           kernel_initializer=CONV_KERNEL_INITIALIZER,
+                           name=name + 'se_expand')(se)
         if backend.backend() == 'theano':
             # For the Theano backend, we have to explicitly make
             # the excitation weights broadcastable.
-            se_tensor = layers.Lambda(
+            se = layers.Lambda(
                 lambda x: backend.pattern_broadcast(x, [True, True, True, False]),
                 output_shape=lambda input_shape: input_shape,
-                name=name + 'se_broadcast')(se_tensor)
-        x = layers.multiply([x, se_tensor], name=name + 'se_excite')
+                name=name + 'se_broadcast')(se)
+        x = layers.multiply([x, se], name=name + 'se_excite')
 
     # Output phase
-    x = layers.Conv2D(kwargs['filters_out'], 1,
+    x = layers.Conv2D(filters_out, 1,
                       padding='same',
                       use_bias=False,
                       kernel_initializer=CONV_KERNEL_INITIALIZER,
                       name=name + 'project_conv')(x)
     x = layers.BatchNormalization(axis=bn_axis, name=name + 'project_bn')(x)
-    if (kwargs['id_skip'] and all(s == 1 for s in kwargs['strides']) and
-            kwargs['filters_in'] == kwargs['filters_out']):
-        if drop_rate and (drop_rate > 0):
+    if (id_skip is True and strides == 1 and filters_in == filters_out):
+        if drop_rate > 0:
             x = layers.Dropout(drop_rate,
                                noise_shape=(None, 1, 1, 1),
                                name=name + 'drop')(x)
@@ -238,11 +227,12 @@ def EfficientNet(width_coefficient,
     # Arguments
         width_coefficient: float, scaling coefficient for network width.
         depth_coefficient: float, scaling coefficient for network depth.
-        default_size: int, default input image size.
+        default_size: integer, default input image size.
         dropout_rate: float, dropout rate before final classifier layer.
         drop_connect_rate: float, dropout rate at skip connections.
-        depth_divisor: int.
-        blocks_args: A list of BlockArgs to construct block modules.
+        depth_divisor: integer, a unit of network width.
+        activation_fn: activation function.
+        blocks_args: list of dicts, parameters to construct block modules.
         model_name: string, model name.
         include_top: whether to include the fully-connected
             layer at the top of the network.
@@ -308,10 +298,23 @@ def EfficientNet(width_coefficient,
 
     bn_axis = 3 if backend.image_data_format() == 'channels_last' else 1
 
+    def round_filters(filters, divisor=depth_divisor):
+        """Round number of filters based on depth multiplier."""
+        filters *= width_coefficient
+        new_filters = max(divisor, int(filters + divisor / 2) // divisor * divisor)
+        # Make sure that round down does not go down by more than 10%.
+        if new_filters < 0.9 * filters:
+            new_filters += divisor
+        return int(new_filters)
+
+    def round_repeats(repeats):
+        """Round number of repeats based on depth multiplier."""
+        return int(math.ceil(depth_coefficient * repeats))
+
     # Build stem
     x = img_input
-    x = layers.Conv2D(round_filters(32, width_coefficient, depth_divisor), 3,
-                      strides=(2, 2),
+    x = layers.Conv2D(round_filters(32), 3,
+                      strides=2,
                       padding='same',
                       use_bias=False,
                       kernel_initializer=CONV_KERNEL_INITIALIZER,
@@ -323,35 +326,25 @@ def EfficientNet(width_coefficient,
     from copy import deepcopy
     blocks_args = deepcopy(blocks_args)
 
-    num_blocks_total = sum(block_args['repeats'] for block_args in blocks_args)
-    block_num = 0
-    for (idx, block_args) in enumerate(blocks_args):
-        assert block_args['repeats'] > 0
+    b = 0
+    blocks = float(sum(args['repeats'] for args in blocks_args))
+    for (i, args) in enumerate(blocks_args):
+        assert args['repeats'] > 0
         # Update block input and output filters based on depth multiplier.
-        block_args['filters_in'] = round_filters(
-            block_args['filters_in'], width_coefficient, depth_divisor)
-        block_args['filters_out'] = round_filters(
-            block_args['filters_out'], width_coefficient, depth_divisor)
-        block_args['repeats'] = round_repeats(
-            block_args['repeats'], depth_coefficient)
+        args['filters_in'] = round_filters(args['filters_in'])
+        args['filters_out'] = round_filters(args['filters_out'])
 
-        # The first block needs to take care of stride and filter size increase.
-        drop_rate = drop_connect_rate * float(block_num) / num_blocks_total
-        x = block(x, drop_rate, activation_fn,
-                  name='block{}a_'.format(idx + 1), **block_args)
-        block_num += 1
-        if block_args['repeats'] > 1:
-            block_args['filters_in'] = block_args['filters_out']
-            block_args['strides'] = [1, 1]
-            for bidx in range(block_args['repeats'] - 1):
-                drop_rate = drop_connect_rate * float(block_num) / num_blocks_total
-                x = block(x, drop_rate, activation_fn,
-                          name='block{}{}_'.format(idx + 1, chr(bidx + 98)),
-                          **block_args)
-                block_num += 1
+        for j in range(round_repeats(args.pop('repeats'))):
+            # The first block needs to take care of stride and filter size increase.
+            if j > 0:
+                args['strides'] = 1
+                args['filters_in'] = args['filters_out']
+            x = block(x, activation_fn, drop_connect_rate * b / blocks,
+                      name='block{}{}_'.format(i + 1, chr(j + 97)), **args)
+            b += 1
 
     # Build top
-    x = layers.Conv2D(round_filters(1280, width_coefficient, depth_divisor), 1,
+    x = layers.Conv2D(round_filters(1280), 1,
                       padding='same',
                       use_bias=False,
                       kernel_initializer=CONV_KERNEL_INITIALIZER,
@@ -360,7 +353,7 @@ def EfficientNet(width_coefficient,
     x = layers.Activation(activation_fn, name='top_activation')(x)
     if include_top:
         x = layers.GlobalAveragePooling2D(name='avg_pool')(x)
-        if dropout_rate and dropout_rate > 0:
+        if dropout_rate > 0:
             x = layers.Dropout(dropout_rate, name='top_dropout')(x)
         x = layers.Dense(classes,
                          activation='softmax',

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -36,30 +36,38 @@ BASE_WEIGHTS_PATH = (
     'https://github.com/Callidior/keras-applications/'
     'releases/download/efficientnet/')
 WEIGHTS_HASHES = {
-    'efficientnet-b0': ('dd631faed10515e2cd08e3b5da0624b3'
-                        'f50d523fe69b9b5fdf037365f9f907f0',
-                        'e5649d29a9f2dd60380dd05d63389666'
-                        '1c36e1f9596e302a305f9ff1774c1bc8'),
-    'efficientnet-b1': ('3b88771863db84f3ddea6d722a818719'
-                        '04e0fa6288869a0adaa85059094974bb',
-                        '5b47361e17c7bd1d21e42add4456960c'
-                        '9312f71b57b9f6d548e85b7ad9243bdf'),
-    'efficientnet-b2': ('e78c89b8580d907238fd45f8ef200131'
-                        '95d198d16135fadc80650b2453f64f6c',
-                        'ac3c2de4e43096d2979909dd9ec22119'
-                        'c3a34a9fd3cbda9977c1d05f7ebcede9'),
-    'efficientnet-b3': ('99725ac825f7ddf5e47c05d333d9fb62'
-                        '3faf1640c0b0c7372f855804e1861508',
-                        'e70d7ea35fa684f9046e6cc62783940b'
-                        'd83d16edc238807fb75c73105d7ffbaa'),
-    'efficientnet-b4': ('242890effb990b11fdcc91fceb59cd74'
-                        '9388c6b712c96dfb597561d6dae3060a',
-                        'eaa6455c773db0f2d4d097f7da771bb7'
-                        '25dd8c993ac6f4553b78e12565999fc1'),
-    'efficientnet-b5': ('c4cb66916633b7311688dbcf6ed5c35e'
-                        '45ce06594181066015c001103998dc67',
-                        '14161a20506013aa229abce8fd994b45'
-                        'da76b3a29e1c011635376e191c2c2d54')
+    'efficientnet-b0': ('163292582f1c6eaca8e7dc7b51b01c61'
+                        '5b0dbc0039699b4dcd0b975cc21533dc',
+                        'c1421ad80a9fc67c2cc4000f666aa507'
+                        '89ce39eedb4e06d531b0c593890ccff3'),
+    'efficientnet-b1': ('d0a71ddf51ef7a0ca425bab32b7fa7f1'
+                        '6043ee598ecee73fc674d9560c8f09b0',
+                        '75de265d03ac52fa74f2f510455ba64f'
+                        '9c7c5fd96dc923cd4bfefa3d680c4b68'),
+    'efficientnet-b2': ('bb5451507a6418a574534aa76a91b106'
+                        'f6b605f3b5dde0b21055694319853086',
+                        '433b60584fafba1ea3de07443b74cfd3'
+                        '2ce004a012020b07ef69e22ba8669333'),
+    'efficientnet-b3': ('03f1fba367f070bd2545f081cfa7f3e7'
+                        '6f5e1aa3b6f4db700f00552901e75ab9',
+                        'c5d42eb6cfae8567b418ad3845cfd63a'
+                        'a48b87f1bd5df8658a49375a9f3135c7'),
+    'efficientnet-b4': ('98852de93f74d9833c8640474b2c698d'
+                        'b45ec60690c75b3bacb1845e907bf94f',
+                        '7942c1407ff1feb34113995864970cd4'
+                        'd9d91ea64877e8d9c38b6c1e0767c411'),
+    'efficientnet-b5': ('30172f1d45f9b8a41352d4219bf930ee'
+                        '3339025fd26ab314a817ba8918fefc7d',
+                        '9d197bc2bfe29165c10a2af8c2ebc675'
+                        '07f5d70456f09e584c71b822941b1952'),
+    'efficientnet-b6': ('f5270466747753485a082092ac9939ca'
+                        'a546eb3f09edca6d6fff842cad938720',
+                        '1d0923bb038f2f8060faaf0a0449db4b'
+                        '96549a881747b7c7678724ac79f427ed'),
+    'efficientnet-b7': ('876a41319980638fa597acbbf956a82d'
+                        '10819531ff2dcb1a52277f10c7aefa1a',
+                        '60b56ff3a8daccc8d96edfd40b204c11'
+                        '3e51748da657afd58034d54d3cec2bac')
 }
 
 MEAN_RGB = [0.485 * 255, 0.456 * 255, 0.406 * 255]

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -311,11 +311,6 @@ def EfficientNet(width_coefficient,
         raise ValueError('If using `weights` as `"imagenet"` with `include_top`'
                          ' as true, `classes` should be 1000')
 
-    if weights == 'imagenet' and (model_name not in WEIGHTS_HASHES):
-        raise ValueError('Pre-trained weights are only available for '
-                         'EfficientNet-B0 to -B5, but you requested weights for ' +
-                         model_name + '.')
-
     # Determine proper input shape
     input_shape = _obtain_input_shape(input_shape,
                                       default_size=default_resolution,

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -107,6 +107,18 @@ def conv_kernel_initializer(shape, dtype=None):
     return backend.random_normal(shape, mean=0.0, stddev=np.sqrt(2.0 / fan_out), dtype=dtype)
 
 
+def dense_kernel_initializer(shape, dtype=None):
+    """Initialization for dense kernels.
+    
+    This initialization is equal to
+    keras.initializers.VarianceScaling(scale=1.0/3.0, mode='fan_out',
+                                       distribution='uniform').
+    """
+
+    init_range = 1.0 / np.sqrt(shape[1])
+    return backend.random_uniform(shape, -init_range, init_range, dtype=dtype)
+
+
 def round_filters(filters, width_coefficient, depth_divisor):
     """Round number of filters based on width multiplier."""
 
@@ -337,9 +349,7 @@ def EfficientNet(width_coefficient,
         x = layers.GlobalAveragePooling2D(name='avg_pool')(x)
         if dropout_rate and dropout_rate > 0:
             x = layers.Dropout(dropout_rate, name='top_dropout')(x)
-        # kernel_initializer in reference implementation:
-        # keras.initializers.VarianceScaling(1.0/3.0, mode='fan_out', distribution='uniform')
-        x = layers.Dense(classes, activation='softmax', name='probs')(x)
+        x = layers.Dense(classes, activation='softmax', kernel_initializer=dense_kernel_initializer, name='probs')(x)
     else:
         if pooling == 'avg':
             x = layers.GlobalAveragePooling2D(name='avg_pool')(x)

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -281,6 +281,10 @@ def EfficientNet(width_coefficient,
         raise ValueError('If using `weights` as `"imagenet"` with `include_top`'
                          ' as true, `classes` should be 1000')
 
+    if weights == 'imagenet' and (model_name not in WEIGHTS_HASHES):
+        raise ValueError('Pre-trained weights are only available for EfficientNet-B0 to -B3,'
+                         'but you requested weights for ' + model_name + '.')
+
     # Determine proper input shape
     input_shape = _obtain_input_shape(input_shape,
                                       default_size=default_resolution,

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -64,7 +64,6 @@ WEIGHTS_HASHES = {
 
 MEAN_RGB = [0.485 * 255, 0.456 * 255, 0.406 * 255]
 STDDEV_RGB = [0.229 * 255, 0.224 * 255, 0.225 * 255]
-_MEAN_RGB_TENSOR = None
 
 
 BlockArgs = collections.namedtuple('BlockArgs', [
@@ -574,15 +573,12 @@ def preprocess_input(x, **kwargs):
 
     else:
 
-        global _MEAN_RGB_TENSOR
-
-        if _MEAN_RGB_TENSOR is None:
-            _MEAN_RGB_TENSOR = backend.constant(-np.array(MEAN_RGB))
+        mean_tensor = backend.constant(-np.array(MEAN_RGB))
 
         # Zero-center by mean pixel
-        if backend.dtype(x) != backend.dtype(_MEAN_RGB_TENSOR):
+        if backend.dtype(x) != backend.dtype(mean_tensor):
             x = backend.bias_add(
-                x, backend.cast(_MEAN_RGB_TENSOR, backend.dtype(x)))
+                x, backend.cast(mean_tensor, backend.dtype(x)))
         else:
-            x = backend.bias_add(x, _MEAN_RGB_TENSOR)
+            x = backend.bias_add(x, mean_tensor)
         return x / STDDEV_RGB

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -191,6 +191,12 @@ def mb_conv_block(inputs, block_args, drop_rate=None, relu_fn=swish, prefix=''):
                                   use_bias=True,
                                   kernel_initializer=CONV_KERNEL_INITIALIZER,
                                   name=prefix + 'se_expand')(se_tensor)
+        if backend.backend() == 'theano':
+            # For the Theano backend, we have to explicitly make
+            # the excitation weights broadcastable.
+            se_tensor = layers.Lambda(
+                lambda x: backend.pattern_broadcast(x, [True, True, True, False]),
+                name=prefix + 'se_broadcast')(se_tensor)
         x = layers.multiply([x, se_tensor], name=prefix + 'se_excite')
 
     # Output phase

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -409,11 +409,12 @@ def EfficientNet(width_coefficient,
     # Load weights.
     if weights == 'imagenet':
         if include_top:
-            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_autoaugment.h5'
+            file_suff = '_weights_tf_dim_ordering_tf_kernels_autoaugment.h5'
             file_hash = WEIGHTS_HASHES[model_name][0]
         else:
-            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_autoaugment_notop.h5'
+            file_suff = '_weights_tf_dim_ordering_tf_kernels_autoaugment_notop.h5'
             file_hash = WEIGHTS_HASHES[model_name][1]
+        file_name = model_name + file_suff
         weights_path = keras_utils.get_file(file_name,
                                             BASE_WEIGHTS_PATH + file_name,
                                             cache_subdir='models',

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -90,8 +90,9 @@ CONV_KERNEL_INITIALIZER = {
     'config': {
         'scale': 2.0,
         'mode': 'fan_out',
-        # EfficientNet actually uses a truncated normal distribution for initializing
-        # conv layers, but keras.initializers.VarianceScaling does not provide this.
+        # EfficientNet actually uses an untruncated normal distribution for
+        # initializing conv layers, but keras.initializers.VarianceScaling use
+        # a truncated distribution.
         # We decided against a custom initializer for better serializability.
         'distribution': 'normal'
     }

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -191,6 +191,7 @@ def block(inputs, drop_rate=None, activation_fn=swish, name='', **kwargs):
             # the excitation weights broadcastable.
             se_tensor = layers.Lambda(
                 lambda x: backend.pattern_broadcast(x, [True, True, True, False]),
+                output_shape=lambda input_shape: input_shape,
                 name=name + 'se_broadcast')(se_tensor)
         x = layers.multiply([x, se_tensor], name=name + 'se_excite')
 

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -409,10 +409,10 @@ def EfficientNet(width_coefficient,
     # Load weights.
     if weights == 'imagenet':
         if include_top:
-            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels.h5'
+            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_autoaugment.h5'
             file_hash = WEIGHTS_HASHES[model_name][0]
         else:
-            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_notop.h5'
+            file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_autoaugment_notop.h5'
             file_hash = WEIGHTS_HASHES[model_name][1]
         weights_path = keras_utils.get_file(file_name,
                                             BASE_WEIGHTS_PATH + file_name,

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -33,11 +33,17 @@ keras_utils = None
 
 
 BASE_WEIGHTS_PATH = (
-    'https://github.com/keras-team/keras-applications/'
+    'https://github.com/Callidior/keras-applications/'
     'releases/download/efficientnet/')
 WEIGHTS_HASHES = {
-    'efficientnet-b0': ('e423137a2235dfc8166aac54ba9f306fb1f2f77843d88f9437079952e9b3622f',
-                        '')
+    'efficientnet-b0': ('dd631faed10515e2cd08e3b5da0624b3f50d523fe69b9b5fdf037365f9f907f0',
+                        'e5649d29a9f2dd60380dd05d633896661c36e1f9596e302a305f9ff1774c1bc8'),
+    'efficientnet-b1': ('3b88771863db84f3ddea6d722a81871904e0fa6288869a0adaa85059094974bb',
+                        '5b47361e17c7bd1d21e42add4456960c9312f71b57b9f6d548e85b7ad9243bdf'),
+    'efficientnet-b2': ('e78c89b8580d907238fd45f8ef20013195d198d16135fadc80650b2453f64f6c',
+                        'ac3c2de4e43096d2979909dd9ec22119c3a34a9fd3cbda9977c1d05f7ebcede9'),
+    'efficientnet-b3': ('99725ac825f7ddf5e47c05d333d9fb623faf1640c0b0c7372f855804e1861508',
+                        'e70d7ea35fa684f9046e6cc62783940bd83d16edc238807fb75c73105d7ffbaa')
 }
 
 MEAN_RGB = [0.485 * 255, 0.456 * 255, 0.406 * 255]
@@ -342,7 +348,7 @@ def EfficientNet(width_coefficient,
     model = models.Model(inputs, x, name=model_name)
 
     # Load weights.
-    if (weights == 'imagenet') and (model_name in WEIGHTS_HASHES):
+    if weights == 'imagenet':
         if include_top:
             file_name = model_name + '_weights_tf_dim_ordering_tf_kernels.h5'
             file_hash = WEIGHTS_HASHES[model_name][0]

--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -38,38 +38,22 @@ BASE_WEIGHTS_PATH = (
     'https://github.com/Callidior/keras-applications/'
     'releases/download/efficientnet/')
 WEIGHTS_HASHES = {
-    'efficientnet-b0': ('163292582f1c6eaca8e7dc7b51b01c61'
-                        '5b0dbc0039699b4dcd0b975cc21533dc',
-                        'c1421ad80a9fc67c2cc4000f666aa507'
-                        '89ce39eedb4e06d531b0c593890ccff3'),
-    'efficientnet-b1': ('d0a71ddf51ef7a0ca425bab32b7fa7f1'
-                        '6043ee598ecee73fc674d9560c8f09b0',
-                        '75de265d03ac52fa74f2f510455ba64f'
-                        '9c7c5fd96dc923cd4bfefa3d680c4b68'),
-    'efficientnet-b2': ('bb5451507a6418a574534aa76a91b106'
-                        'f6b605f3b5dde0b21055694319853086',
-                        '433b60584fafba1ea3de07443b74cfd3'
-                        '2ce004a012020b07ef69e22ba8669333'),
-    'efficientnet-b3': ('03f1fba367f070bd2545f081cfa7f3e7'
-                        '6f5e1aa3b6f4db700f00552901e75ab9',
-                        'c5d42eb6cfae8567b418ad3845cfd63a'
-                        'a48b87f1bd5df8658a49375a9f3135c7'),
-    'efficientnet-b4': ('98852de93f74d9833c8640474b2c698d'
-                        'b45ec60690c75b3bacb1845e907bf94f',
-                        '7942c1407ff1feb34113995864970cd4'
-                        'd9d91ea64877e8d9c38b6c1e0767c411'),
-    'efficientnet-b5': ('30172f1d45f9b8a41352d4219bf930ee'
-                        '3339025fd26ab314a817ba8918fefc7d',
-                        '9d197bc2bfe29165c10a2af8c2ebc675'
-                        '07f5d70456f09e584c71b822941b1952'),
-    'efficientnet-b6': ('f5270466747753485a082092ac9939ca'
-                        'a546eb3f09edca6d6fff842cad938720',
-                        '1d0923bb038f2f8060faaf0a0449db4b'
-                        '96549a881747b7c7678724ac79f427ed'),
-    'efficientnet-b7': ('876a41319980638fa597acbbf956a82d'
-                        '10819531ff2dcb1a52277f10c7aefa1a',
-                        '60b56ff3a8daccc8d96edfd40b204c11'
-                        '3e51748da657afd58034d54d3cec2bac')
+    'b0': ('e9e877068bd0af75e0a36691e03c072c',
+           '345255ed8048c2f22c793070a9c1a130'),
+    'b1': ('8f83b9aecab222a9a2480219843049a1',
+           'b20160ab7b79b7a92897fcb33d52cc61'),
+    'b2': ('b6185fdcd190285d516936c09dceeaa4',
+           'c6e46333e8cddfa702f4d8b8b6340d70'),
+    'b3': ('b2db0f8aac7c553657abb2cb46dcbfbb',
+           'e0cf8654fad9d3625190e30d70d0c17d'),
+    'b4': ('ab314d28135fe552e2f9312b31da6926',
+           'b46702e4754d2022d62897e0618edc7b'),
+    'b5': ('8d60b903aff50b09c6acf8eaba098e09',
+           '0a839ac36e46552a881f2975aaab442f'),
+    'b6': ('a967457886eac4f5ab44139bdd827920',
+           '375a35c17ef70d46f9c664b03b4437f2'),
+    'b7': ('e964fd6e26e9a4c144bcb811f2a10f20',
+           'd55674cc46b805f4382d18bc08ed43c1')
 }
 
 
@@ -412,10 +396,10 @@ def EfficientNet(width_coefficient,
     if weights == 'imagenet':
         if include_top:
             file_suff = '_weights_tf_dim_ordering_tf_kernels_autoaugment.h5'
-            file_hash = WEIGHTS_HASHES[model_name][0]
+            file_hash = WEIGHTS_HASHES[model_name[-2:]][0]
         else:
             file_suff = '_weights_tf_dim_ordering_tf_kernels_autoaugment_notop.h5'
-            file_hash = WEIGHTS_HASHES[model_name][1]
+            file_hash = WEIGHTS_HASHES[model_name[-2:]][1]
         file_name = model_name + file_suff
         weights_path = keras_utils.get_file(file_name,
                                             BASE_WEIGHTS_PATH + file_name,

--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -39,11 +39,12 @@ def keras_modules_injection(base_fun):
 
 for (name, module) in [('resnet', keras_applications.resnet),
                        ('resnet_v2', keras_applications.resnet_v2),
-                       ('resnext', keras_applications.resnext)]:
+                       ('resnext', keras_applications.resnext),
+                       ('efficientnet', keras_applications.efficientnet)]:
     module.decode_predictions = keras_modules_injection(module.decode_predictions)
     module.preprocess_input = keras_modules_injection(module.preprocess_input)
     for app in dir(module):
-        if app[0].isupper():
+        if app[0].isupper() and callable(getattr(module, app)):
             setattr(module, app, keras_modules_injection(getattr(module, app)))
     setattr(keras_applications, name, module)
 
@@ -63,6 +64,14 @@ DENSENET_LIST = [(densenet.DenseNet121, 1024),
                  (densenet.DenseNet201, 1920)]
 NASNET_LIST = [(nasnet.NASNetMobile, 1056),
                (nasnet.NASNetLarge, 4032)]
+EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280),
+                     (keras_applications.efficientnet.EfficientNetB1, 1280),
+                     (keras_applications.efficientnet.EfficientNetB2, 1408),
+                     (keras_applications.efficientnet.EfficientNetB3, 1536),
+                     (keras_applications.efficientnet.EfficientNetB4, 1792),
+                     (keras_applications.efficientnet.EfficientNetB5, 2048),
+                     (keras_applications.efficientnet.EfficientNetB6, 2304),
+                     (keras_applications.efficientnet.EfficientNetB7, 2560)]
 
 
 def keras_test(func):
@@ -270,6 +279,15 @@ def test_nasnet():
     _test_application_basic(app, module=module)
     # _test_application_notop(app, last_dim)
     # _test_application_variable_input_channels(app, last_dim)
+    _test_app_pooling(app, last_dim)
+
+
+def test_efficientnet():
+    app, last_dim = random.choice(EFFICIENTNET_LIST)
+    module = keras_applications.efficientnet
+    _test_application_basic(app, module=module)
+    _test_application_notop(app, last_dim)
+    _test_application_variable_input_channels(app, last_dim)
     _test_app_pooling(app, last_dim)
 
 

--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -64,14 +64,14 @@ DENSENET_LIST = [(densenet.DenseNet121, 1024),
                  (densenet.DenseNet201, 1920)]
 NASNET_LIST = [(nasnet.NASNetMobile, 1056),
                (nasnet.NASNetLarge, 4032)]
-EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280, True),
-                     (keras_applications.efficientnet.EfficientNetB1, 1280, True),
-                     (keras_applications.efficientnet.EfficientNetB2, 1408, True),
-                     (keras_applications.efficientnet.EfficientNetB3, 1536, True),
-                     (keras_applications.efficientnet.EfficientNetB4, 1792, True),
-                     (keras_applications.efficientnet.EfficientNetB5, 2048, True),
-                     (keras_applications.efficientnet.EfficientNetB6, 2304, False),
-                     (keras_applications.efficientnet.EfficientNetB7, 2560, False)]
+EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280),
+                     (keras_applications.efficientnet.EfficientNetB1, 1280),
+                     (keras_applications.efficientnet.EfficientNetB2, 1408),
+                     (keras_applications.efficientnet.EfficientNetB3, 1536),
+                     (keras_applications.efficientnet.EfficientNetB4, 1792),
+                     (keras_applications.efficientnet.EfficientNetB5, 2048),
+                     (keras_applications.efficientnet.EfficientNetB6, 2304),
+                     (keras_applications.efficientnet.EfficientNetB7, 2560)]
 
 
 def keras_test(func):
@@ -283,9 +283,7 @@ def test_nasnet():
 
 
 def test_efficientnet():
-    has_weights = False
-    while not has_weights:
-        app, last_dim, has_weights = random.choice(EFFICIENTNET_LIST)
+    app, last_dim = random.choice(EFFICIENTNET_LIST)
     module = keras_applications.efficientnet
     _test_application_basic(app, module=module)
     _test_application_notop(app, last_dim)

--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -68,8 +68,8 @@ EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280, True
                      (keras_applications.efficientnet.EfficientNetB1, 1280, True),
                      (keras_applications.efficientnet.EfficientNetB2, 1408, True),
                      (keras_applications.efficientnet.EfficientNetB3, 1536, True),
-                     (keras_applications.efficientnet.EfficientNetB4, 1792, False),
-                     (keras_applications.efficientnet.EfficientNetB5, 2048, False),
+                     (keras_applications.efficientnet.EfficientNetB4, 1792, True),
+                     (keras_applications.efficientnet.EfficientNetB5, 2048, True),
                      (keras_applications.efficientnet.EfficientNetB6, 2304, False),
                      (keras_applications.efficientnet.EfficientNetB7, 2560, False)]
 

--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -69,8 +69,7 @@ EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280),
                      (keras_applications.efficientnet.EfficientNetB2, 1408),
                      (keras_applications.efficientnet.EfficientNetB3, 1536),
                      (keras_applications.efficientnet.EfficientNetB4, 1792),
-                     (keras_applications.efficientnet.EfficientNetB5, 2048),
-                     (keras_applications.efficientnet.EfficientNetB6, 2304)]
+                     (keras_applications.efficientnet.EfficientNetB5, 2048)]
 
 
 def keras_test(func):

--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -70,8 +70,7 @@ EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280),
                      (keras_applications.efficientnet.EfficientNetB3, 1536),
                      (keras_applications.efficientnet.EfficientNetB4, 1792),
                      (keras_applications.efficientnet.EfficientNetB5, 2048),
-                     (keras_applications.efficientnet.EfficientNetB6, 2304),
-                     (keras_applications.efficientnet.EfficientNetB7, 2560)]
+                     (keras_applications.efficientnet.EfficientNetB6, 2304)]
 
 
 def keras_test(func):

--- a/tests/applications_test.py
+++ b/tests/applications_test.py
@@ -64,14 +64,14 @@ DENSENET_LIST = [(densenet.DenseNet121, 1024),
                  (densenet.DenseNet201, 1920)]
 NASNET_LIST = [(nasnet.NASNetMobile, 1056),
                (nasnet.NASNetLarge, 4032)]
-EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280),
-                     (keras_applications.efficientnet.EfficientNetB1, 1280),
-                     (keras_applications.efficientnet.EfficientNetB2, 1408),
-                     (keras_applications.efficientnet.EfficientNetB3, 1536),
-                     (keras_applications.efficientnet.EfficientNetB4, 1792),
-                     (keras_applications.efficientnet.EfficientNetB5, 2048),
-                     (keras_applications.efficientnet.EfficientNetB6, 2304),
-                     (keras_applications.efficientnet.EfficientNetB7, 2560)]
+EFFICIENTNET_LIST = [(keras_applications.efficientnet.EfficientNetB0, 1280, True),
+                     (keras_applications.efficientnet.EfficientNetB1, 1280, True),
+                     (keras_applications.efficientnet.EfficientNetB2, 1408, True),
+                     (keras_applications.efficientnet.EfficientNetB3, 1536, True),
+                     (keras_applications.efficientnet.EfficientNetB4, 1792, False),
+                     (keras_applications.efficientnet.EfficientNetB5, 2048, False),
+                     (keras_applications.efficientnet.EfficientNetB6, 2304, False),
+                     (keras_applications.efficientnet.EfficientNetB7, 2560, False)]
 
 
 def keras_test(func):
@@ -283,7 +283,9 @@ def test_nasnet():
 
 
 def test_efficientnet():
-    app, last_dim = random.choice(EFFICIENTNET_LIST)
+    has_weights = False
+    while not has_weights:
+        app, last_dim, has_weights = random.choice(EFFICIENTNET_LIST)
     module = keras_applications.efficientnet
     _test_application_basic(app, module=module)
     _test_application_notop(app, last_dim)


### PR DESCRIPTION
This pull-request is a translation of the [reference implementation][2] of [EfficientNet][1] (ICML 2019) from Tensorflow to Keras.

There are two deviations from the description of EfficientNet in the paper and one deviation from the reference implementation:
- The pooling operation at stage 6 already happens at stage 5 (cf. Table 1 in the paper). This is in accordance with the reference implementation and a mistake in the paper (see [this issue][5]).
- The default drop-connect rate is 0.2, as in the reference implementation. The paper mentioned 0.3 instead (cf. [this issue][6]).
- The reference implementation uses an untruncated normal distribution for initializing convolutional kernels. I decided to stick with built-in keras initializers, however, for better (de)serializability. These use a truncated normal distribution. This does not influence inference with pre-trained weights and the effect on training should be marginal (if any).

Pre-trained weights have been converted from the Tensorflow checkpoints trained with AutoAugment provided by the authors (which perform better than reported in the paper) and achieve accuracies comparable to those stated by them:

| Model | Reported in Paper | Official Checkpoint | Converted Weights |
|-------|---------:|---------:|-------:|
| B0 | 76.3% | 77.3% | 77.2% |
| B1 | 78.8% | 79.2% | 79.1% |
| B2 | 79.8% | 80.3% | 80.2% |
| B3 | 81.8% | 81.7% | 81.6% |
| B4 | 82.6% | 83.0% | 83.0% |
| B5 | 83.3% | 83.7% | 83.7% |
| B6 | 84.0% | 84.2% | 84.1% |
| B7 | 84.4% | 84.5% | 84.4% |

The weights are currently hosted on my [GitHub repository][8] and will be downloaded automatically by the EfficientNet implementation. Upon merge, however, it would be reasonable to transfer them to the `keras-team/keras-applications` repository.

---

#### To Do

- [x] Re-implement model architecture
- [x] Convert weights and evaluate accuracy on ImageNet
- [x] Test training
- [x] Write unit tests
- [x] Add top-1, top-5, and 10-5 performance of all models to README.md
- [x] Fix squeeze-and-excitation with Theano backend
- [x] PEP-8 conformity

[1]: https://arxiv.org/abs/1905.11946
[2]: https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet
[3]: https://github.com/tensorflow/tpu/blob/05f7b15cdf0ae36bac84beb4aef0a09983ce8f66/models/official/efficientnet/efficientnet_model.py#L408
[5]: https://github.com/tensorflow/tpu/issues/383
[6]: https://github.com/tensorflow/tpu/issues/381
[7]: https://github.com/tensorflow/tpu/issues/377
[8]: https://github.com/Callidior/keras-applications/releases/tag/efficientnet