### PR TITLE
Fix symbolic imagenet preprocessing

### DIFF
--- a/keras_applications/imagenet_utils.py
+++ b/keras_applications/imagenet_utils.py
@@ -113,6 +113,9 @@ def _preprocess_symbolic_input(x, data_format, mode, **kwargs):
 
     backend, _, _, _ = get_submodules_from_kwargs(kwargs)
 
+    if backend.dtype(x) != backend.floatx():
+        x = backend.cast(x, backend.floatx())
+
     if mode == 'tf':
         x /= 127.5
         x -= 1.
@@ -138,12 +141,8 @@ def _preprocess_symbolic_input(x, data_format, mode, **kwargs):
     mean_tensor = backend.constant(-np.array(mean))
 
     # Zero-center by mean pixel
-    if backend.dtype(x) != backend.dtype(mean_tensor):
-        x = backend.bias_add(
-            x, backend.cast(mean_tensor, backend.dtype(x)),
-            data_format=data_format)
-    else:
-        x = backend.bias_add(x, mean_tensor, data_format)
+    x = backend.bias_add(x, mean_tensor, data_format)
+
     if std is not None:
         x /= std
     return x


### PR DESCRIPTION
Related with https://github.com/keras-team/keras-applications/issues/128

When input tensor is `dtype='uint8'` we are casting the `mean_tensor `to be `uint8` and this is not the intended behaviour since we will be losing the floating point precision.
Instead, we want to cast x (image tensor) to be float (floatx) so we can subtract the correct mean_tensor values.

Everyone working with explicit `Tensor(dtype='uint8')` and preprocessing images using preprocess_input will face a buggy channel mean subtraction.