### PR TITLE
Remove h5py hard dependency from keras_applications

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ setup(name='Keras_Applications',
       download_url='https://github.com/keras-team/'
                    'keras-applications/tarball/1.0.8',
       license='MIT',
-      install_requires=['numpy>=1.9.1',
-                        'h5py'],
+      install_requires=['numpy>=1.9.1'],
       extras_require={
           'tests': ['pytest',
                     'pytest-pep8',


### PR DESCRIPTION
This PR tries to remove h5py hard dependency from
keras_applications. Searching from the repo, it looks like
h5py only appears in setup.py.

By removing h5py from setup.py, it should help with python 3.8
support as h5py could not be installed with pytohn 3.8 on Ubuntu/Linux.

This PR fixes #147.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>