### PR TITLE
Stop exporting resnet50.py

### DIFF
--- a/keras_applications/__init__.py
+++ b/keras_applications/__init__.py
@@ -52,7 +52,6 @@ __version__ = '1.0.8'
 
 from . import vgg16
 from . import vgg19
-from . import resnet50
 from . import inception_v3
 from . import inception_resnet_v2
 from . import xception


### PR DESCRIPTION
resnet50.py contains old implementation, and it is actually silently cover the new implementation which we want to export in resnet.py.

This should fix the confusion in https://github.com/tensorflow/tensorflow/issues/33459.