### PR TITLE
Fix Squeeze for channel first network creation

### DIFF
--- a/keras_applications/efficientnet.py
+++ b/keras_applications/efficientnet.py
@@ -172,7 +172,10 @@ def block(inputs, activation_fn=swish, drop_rate=0., name='',
     if 0 < se_ratio <= 1:
         filters_se = max(1, int(filters_in * se_ratio))
         se = layers.GlobalAveragePooling2D(name=name + 'se_squeeze')(x)
-        se = layers.Reshape((1, 1, filters), name=name + 'se_reshape')(se)
+        if bn_axis == 1:
+            se = layers.Reshape((filters, 1, 1), name=name + 'se_reshape')(se)
+        else:
+            se = layers.Reshape((1, 1, filters), name=name + 'se_reshape')(se)
         se = layers.Conv2D(filters_se, 1,
                            padding='same',
                            activation=activation_fn,


### PR DESCRIPTION
The current efficientnet implementation does not work in channel first mode, because the reshape dimensions are hardcoded to channel last. This fix adds full channel first support